### PR TITLE
Escape env vars in the uwsgi template to avoid conflicts with how uwsgi does magic variables

### DIFF
--- a/ansible/roles/halliganhelper/templates/uwsgi-base.ini.jinja2
+++ b/ansible/roles/halliganhelper/templates/uwsgi-base.ini.jinja2
@@ -5,9 +5,9 @@ home        = %(root)/envs/current
 plugins     = python2 
 
 env         = DEBUG=False
-env         = STATIC_ROOT={{ static_root }}
-env         = MEDIA_ROOT={{ media_root }}
-env         = EMAIL_PASSWORD={{ email_password }}
-env         = DB_PASSWORD={{ db_password }}
-env         = REDIS_PASSWORD={{ redis_password }}
-env         = SECRET_KEY={{ django_secret_key }}
+env         = STATIC_ROOT={{ static_root|replace('%', '%%') }}
+env         = MEDIA_ROOT={{ media_root|replace('%', '%%') }}
+env         = EMAIL_PASSWORD={{ email_password|replace('%', '%%') }}
+env         = DB_PASSWORD={{ db_password|replace('%', '%%') }}
+env         = REDIS_PASSWORD={{ redis_password|replace('%', '%%') }}
+env         = SECRET_KEY={{ django_secret_key|replace('%', '%%') }}


### PR DESCRIPTION
Second part of a fix for #47 
