### PR TITLE
Actually use gevent for websockets

### DIFF
--- a/ansible/roles/halliganhelper/templates/uwsgi-halliganhelper-sockets.ini.jinja2
+++ b/ansible/roles/halliganhelper/templates/uwsgi-halliganhelper-sockets.ini.jinja2
@@ -3,11 +3,12 @@ ini              = /etc/uwsgi/vassals/uwsgi-base.ini
 
 module           = HalliganAvailability.wsgi_websocket
 master           = true
-processes        = 4
 http-socket      = 127.0.0.1:8002
 vacuum           = true
+plugins          = python,gevent2
 gevent           = 1000
-workers          = 2
+processes        = 1
+threads          = 1
 http-websockets  = true
 
 logto       = /var/log/hh/uwsgi-sockets.log


### PR DESCRIPTION
We previously tried to use gevent but didn't tell uWSGI to load the proper plugin, so it was falling back to the standard synchronous mode. As a result, each worker could only handle one WebSocket connection and so no more than 2 clients could receive notifications.
